### PR TITLE
Add City Distance skill and examples

### DIFF
--- a/skills/city-distance/EXAMPLES.md
+++ b/skills/city-distance/EXAMPLES.md
@@ -1,0 +1,16 @@
+# City Distance Examples
+
+This file contains example calculations performed by the agent using the City Distance skill.
+
+## Paris — Berlin
+- Coordinates: Paris (48.8566, 2.3522) → Berlin (52.52, 13.4050)
+- Line-of-sight (Haversine): 878.8 km
+- Road distance (OSM routing): 1,050.73 km
+- Source: https://routing.openstreetmap.de/routed-car/route/v1/driving/2.3522,48.8566;13.4050,52.52?overview=false
+
+## Paris — Dubai
+- Coordinates: Paris (48.8566, 2.3522) → Dubai (25.2048, 55.2708)
+- Line-of-sight (Haversine): 5,274 km
+- Road distance (OSM routing): 6,531.03 km
+- Source: https://routing.openstreetmap.de/routed-car/route/v1/driving/2.3522,48.8566;55.2708,25.2048?overview=false
+

--- a/skills/city-distance/SKILL.md
+++ b/skills/city-distance/SKILL.md
@@ -1,0 +1,20 @@
+# City Distance Skill
+
+Purpose: Calculate line-of-sight and road distances between two cities using free, API-keyless public services and local haversine calculations.
+
+What it does:
+- Computes line-of-sight distance using the Haversine formula.
+- Uses OpenStreetMap routing endpoint (routing.openstreetmap.de) to compute road distance without an API key.
+- Optionally lists intermediate cities by sampling points along the route and reverse-geocoding with Nominatim (free) to find nearby settlements.
+
+Files:
+- city_distance_calculator.js — example Node.js script demonstrating the calculations.
+
+Usage:
+1. Run `node city_distance_calculator.js` with Node.js 18+ (or install node-fetch for older Node versions).
+2. The script prints line-of-sight and road distances.
+
+Notes / Rate limits:
+- routing.openstreetmap.de and Nominatim are public services and have usage policies and rate limits. Use respectfully (cache results, avoid heavy automated polling).
+- For production-grade use, consider hosting your own OSRM/GraphHopper instance or using a commercial API with SLA.
+


### PR DESCRIPTION
This PR adds a City Distance skill that calculates line-of-sight and road distances using free OpenStreetMap services, plus example outputs (Paris–Berlin, Paris–Dubai).